### PR TITLE
[MultiTenant] Fixed build failure on Windows

### DIFF
--- a/make/CompileNativeLibraries.gmk
+++ b/make/CompileNativeLibraries.gmk
@@ -87,7 +87,9 @@ include lib/Awt2dLibraries.gmk
 
 include lib/SoundLibraries.gmk
 
-include lib/JGroupLibraries.gmk
+ifeq ($(OPENJDK_TARGET_OS), linux)
+  include lib/JGroupLibraries.gmk
+endif
 
 # Include the corresponding custom file, if present. 
 -include $(CUSTOM_MAKE_DIR)/CompileNativeLibraries.gmk

--- a/test/multi-tenant/TestGetAllTenantIDs.java
+++ b/test/multi-tenant/TestGetAllTenantIDs.java
@@ -21,6 +21,8 @@
 
 /*
  * @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @summary Test data structure integrity while access TenantContainer.tenantContainerMap concurrently
  * @library /lib/testlibrary
  * @build TestGetAllTenantIDs

--- a/test/multi-tenant/TestJGroupDebugMode.sh
+++ b/test/multi-tenant/TestJGroupDebugMode.sh
@@ -23,6 +23,8 @@
 
 #
 # @test TestJGroupDebugMode.sh
+# @requires os.family == "Linux"
+# @requires os.arch == "amd64"
 # @summary test debugging mode of JGroup native implementation
 # @run shell/timeout=300 TestJGroupDebugMode.sh
 #

--- a/test/multi-tenant/TestNoJGroupInit.java
+++ b/test/multi-tenant/TestNoJGroupInit.java
@@ -21,6 +21,8 @@
 import java.lang.reflect.Field;
 
 /* @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @summary test scenario where JGroup will not be initialized
  * @compile TestNoJGroupInit.java
  * @run main/othervm/timeout=300 -XX:+MultiTenant TestNoJGroupInit

--- a/test/multi-tenant/TestStaticFieldIsolation.java
+++ b/test/multi-tenant/TestStaticFieldIsolation.java
@@ -1,6 +1,8 @@
 
 /*
  * @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @summary Test isolation of various static fields
  * @library /lib/testlibrary
  * @run main/othervm -XX:+UseG1GC -XX:+MultiTenant -XX:+TenantDataIsolation TestStaticFieldIsolation

--- a/test/multi-tenant/test/com/alibaba/tenant/TestCpuCfsThrottling.java
+++ b/test/multi-tenant/test/com/alibaba/tenant/TestCpuCfsThrottling.java
@@ -32,6 +32,8 @@ import static jdk.testlibrary.Asserts.*;
 
 /*
  * @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @summary test.com.alibaba.tenant.TestCpuCfsThrottling
  * @library /lib/testlibrary
  * @run main/othervm/bootclasspath -Xint -XX:+MultiTenant -XX:+TenantCpuThrottling -XX:+TenantCpuAccounting

--- a/test/multi-tenant/test/com/alibaba/tenant/TestHierachicalTenants.java
+++ b/test/multi-tenant/test/com/alibaba/tenant/TestHierachicalTenants.java
@@ -27,6 +27,8 @@ import static jdk.testlibrary.Asserts.*;
 
 /*
  * @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @summary Test hierarchical tenants support
  * @library /lib/testlibrary
  * @run main/othervm/bootclasspath -XX:+MultiTenant -XX:+TenantCpuThrottling -Xmx200m -Xms200m

--- a/test/multi-tenant/test/com/alibaba/tenant/TestJGroup.java
+++ b/test/multi-tenant/test/com/alibaba/tenant/TestJGroup.java
@@ -31,6 +31,8 @@ import static java.nio.file.StandardOpenOption.WRITE;
 
 /*
  * @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @summary Test JGroup
  * @library /lib/testlibrary
  * @run main/othervm/bootclasspath -XX:+MultiTenant -XX:+TenantCpuAccounting -XX:+TenantCpuThrottling -XX:+UseG1GC -Xmx200m -Xms200m -Dcom.alibaba.tenant.DebugJGroup=true com.alibaba.tenant.TestJGroup

--- a/test/multi-tenant/test/com/alibaba/tenant/TestJGroupInit.java
+++ b/test/multi-tenant/test/com/alibaba/tenant/TestJGroupInit.java
@@ -34,6 +34,8 @@ import static jdk.testlibrary.Asserts.*;
 
 /*
  * @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @summary Test initialization code of JGroup
  * @library /lib/testlibrary
  * @run main/othervm/bootclasspath -XX:+MultiTenant -XX:+TenantCpuThrottling -XX:+UseG1GC

--- a/test/multi-tenant/test/com/alibaba/tenant/TestJMX.java
+++ b/test/multi-tenant/test/com/alibaba/tenant/TestJMX.java
@@ -15,6 +15,8 @@ import com.alibaba.tenant.TenantContainer;
 import com.alibaba.tenant.TenantException;
 
 /* @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @summary JMX related unit tests
  * @library /lib/testlibrary
  * @compile TestJMX.java

--- a/test/multi-tenant/test/com/alibaba/tenant/TestTenantConfiguration.java
+++ b/test/multi-tenant/test/com/alibaba/tenant/TestTenantConfiguration.java
@@ -21,6 +21,8 @@
 package com.alibaba.tenant;
 
 /* @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @summary test TenantConfiguration facilities
  * @library /lib/testlibrary
  * @run main/othervm/bootclasspath -XX:+MultiTenant -XX:+UseG1GC -XX:+TenantCpuThrottling

--- a/test/multi-tenant/test/com/alibaba/tenant/TestTenantContainer.java
+++ b/test/multi-tenant/test/com/alibaba/tenant/TestTenantContainer.java
@@ -37,6 +37,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.IntStream;
 
 /* @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @summary unit tests for com.alibaba.tenant.TenantContainer
  * @library /lib/testlibrary
  * @compile TestTenantContainer.java

--- a/test/multi-tenant/test/com/alibaba/tenant/TestTenantContainerFactory.java
+++ b/test/multi-tenant/test/com/alibaba/tenant/TestTenantContainerFactory.java
@@ -32,6 +32,8 @@ import static jdk.testlibrary.Asserts.*;
 
 /*
  * @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @library /lib/testlibrary
  * @summary test RCM API based TenantContainerFactory
  * @run main/othervm/bootclasspath -XX:+MultiTenant com.alibaba.tenant.TestTenantContainerFactory

--- a/test/multi-tenant/test/com/alibaba/tenant/TestTenantGlobals.java
+++ b/test/multi-tenant/test/com/alibaba/tenant/TestTenantGlobals.java
@@ -28,6 +28,8 @@ import com.alibaba.tenant.TenantGlobals;
 import static org.junit.Assert.*;
 
 /* @test
+ * @requires os.family == "Linux"
+ * @requires os.arch == "amd64"
  * @summary unit tests for com.alibaba.tenant.TenantGlobals
  * @library /lib/testlibrary
  * @compile TestTenantGlobals.java


### PR DESCRIPTION
Summary: skip jgroup libraries on Windows

Test Plan: jdk/test/multi-tenant

Reviewed-by: kuaiwei, yuleil

Issue: https://github.com/alibaba/dragonwell8/issues/92