### PR TITLE
[Wisp] Modify tests after Wisp experimental flags change

### DIFF
--- a/test/com/alibaba/wisp/ConfigurationCompatibilityCheckTest.java
+++ b/test/com/alibaba/wisp/ConfigurationCompatibilityCheckTest.java
@@ -41,6 +41,7 @@ public class ConfigurationCompatibilityCheckTest {
 
     private static void incompatibility(String... args) throws Exception {
         ArrayList<String> list = new ArrayList<>();
+        list.add("-XX:+UnlockExperimentalVMOptions");
         list.add("-XX:+EnableCoroutine");
         list.addAll(Arrays.asList(args));
         list.add("-version");

--- a/test/com/alibaba/wisp/CoroutineTest.java
+++ b/test/com/alibaba/wisp/CoroutineTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Test low level coroutine implement
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine CoroutineTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine CoroutineTest
  */
 
 import java.dyn.Coroutine;

--- a/test/com/alibaba/wisp/ExecutionTest.java
+++ b/test/com/alibaba/wisp/ExecutionTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Test WispCarrier's multi-task schedule
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ExecutionTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ExecutionTest
  */
 
 

--- a/test/com/alibaba/wisp/IoTest.java
+++ b/test/com/alibaba/wisp/IoTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Test Wisp engine's NIO support
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true IoTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true IoTest
  */
 
 import sun.misc.SharedSecrets;

--- a/test/com/alibaba/wisp/LoadClassInnerWispGuard.java
+++ b/test/com/alibaba/wisp/LoadClassInnerWispGuard.java
@@ -61,6 +61,7 @@ public class LoadClassInnerWispGuard {
      */
     private static void driver() throws Exception {
         ProcessBuilder pb = jdk.testlibrary.ProcessTools.createJavaProcessBuilder(
+                "-XX:+UnlockExperimentalVMOptions",
                 "-XX:+UseWisp2", "-Dcom.alibaba.wisp.allThreadAsWisp=false", "-verbose:class",
                 "-cp", System.getProperty("java.class.path"),
                 LoadClassInnerWispGuard.class.getName(), "1");

--- a/test/com/alibaba/wisp/NormalExitTest.java
+++ b/test/com/alibaba/wisp/NormalExitTest.java
@@ -29,7 +29,7 @@
 
 public class NormalExitTest {
     public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = jdk.testlibrary.ProcessTools.createJavaProcessBuilder("-XX:+UseWisp2", "-version");
+        ProcessBuilder pb = jdk.testlibrary.ProcessTools.createJavaProcessBuilder("-XX:+UnlockExperimentalVMOptions", "-XX:+UseWisp2", "-version");
         jdk.testlibrary.OutputAnalyzer output = new jdk.testlibrary.OutputAnalyzer(pb.start());
         output.shouldNotContain("IllegalArgumentException");
     }

--- a/test/com/alibaba/wisp/ParkTest.java
+++ b/test/com/alibaba/wisp/ParkTest.java
@@ -24,7 +24,7 @@
  * @summary Test Wisp engine park / unpark
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+UseWisp2 ParkTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 ParkTest
  */
 
 

--- a/test/com/alibaba/wisp/TestWispDetailCounter.java
+++ b/test/com/alibaba/wisp/TestWispDetailCounter.java
@@ -36,7 +36,7 @@ import static jdk.testlibrary.Asserts.assertTrue;
  * @summary WispCounterMXBean unit test for Detail profile data
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm/timeout=2000 -XX:+UseWisp2 -Dcom.alibaba.wisp.config=/tmp/wisp.config -Dcom.alibaba.wisp.profile=true -Dcom.alibaba.wisp.enableProfileLog=true -Dcom.alibaba.wisp.logTimeInternalMillis=3000 TestWispDetailCounter
+ * @run main/othervm/timeout=2000 -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.config=/tmp/wisp.config -Dcom.alibaba.wisp.profile=true -Dcom.alibaba.wisp.enableProfileLog=true -Dcom.alibaba.wisp.logTimeInternalMillis=3000 TestWispDetailCounter
  */
 
 public class TestWispDetailCounter {

--- a/test/com/alibaba/wisp/WispMonitorDataTest.java
+++ b/test/com/alibaba/wisp/WispMonitorDataTest.java
@@ -42,7 +42,7 @@ import static jdk.testlibrary.Asserts.assertTrue;
  * @summary WispCounterMXBean unit test for Detail profile data using the API with the specified WispCarrier
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm/timeout=2000 -XX:+UseWisp2 -Dcom.alibaba.wisp.config=/tmp/wisp.config -Dcom.alibaba.wisp.profile=true WispMonitorDataTest
+ * @run main/othervm/timeout=2000 -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.config=/tmp/wisp.config -Dcom.alibaba.wisp.profile=true WispMonitorDataTest
  */
 
 public class WispMonitorDataTest {

--- a/test/com/alibaba/wisp/boot/UnsafeDependencyBugTest.java
+++ b/test/com/alibaba/wisp/boot/UnsafeDependencyBugTest.java
@@ -49,7 +49,7 @@ public class UnsafeDependencyBugTest {
     }
 
     private static void runLauncherWithWisp() throws Exception {
-        Process p = new ProcessBuilder(System.getProperty("java.home") + "/bin/java", "-XX:+EnableCoroutine")
+        Process p = new ProcessBuilder(System.getProperty("java.home") + "/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+EnableCoroutine")
                 .redirectErrorStream(true)
                 .redirectOutput(new File("/dev/null"))
                 .start();

--- a/test/com/alibaba/wisp/bug/CancelTimerAndSleepTest.java
+++ b/test/com/alibaba/wisp/bug/CancelTimerAndSleepTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Test sleep
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true CancelTimerAndSleepTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true CancelTimerAndSleepTest
  */
 
 import sun.misc.SharedSecrets;

--- a/test/com/alibaba/wisp/bug/Id2TaskMapLeakTest.java
+++ b/test/com/alibaba/wisp/bug/Id2TaskMapLeakTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Test for thread WispTask leak
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true Id2TaskMapLeakTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true Id2TaskMapLeakTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/bug/ReleaseWispSocketAndExitTest.java
+++ b/test/com/alibaba/wisp/bug/ReleaseWispSocketAndExitTest.java
@@ -26,7 +26,7 @@
  *      2. task B get the socket S and block on IO.
  *      3. task A exit and clean S's event, now B waiting forever...
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ReleaseWispSocketAndExitTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ReleaseWispSocketAndExitTest
  */
 
 

--- a/test/com/alibaba/wisp/bug/ResetTaskCancelTimerBugTest.java
+++ b/test/com/alibaba/wisp/bug/ResetTaskCancelTimerBugTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test reset task doesn't cancel the current task's timer unexpectedly.
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ResetTaskCancelTimerBugTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ResetTaskCancelTimerBugTest
  */
 
 

--- a/test/com/alibaba/wisp/bug/SelectorInitCriticalTest.java
+++ b/test/com/alibaba/wisp/bug/SelectorInitCriticalTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Test the fix to NPE issue caused by unexpected co-routine yielding on synchronized(lock) in SelectorProvider.provider() during initialization of WispCarrier
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true -XX:+UseWispMonitor SelectorInitCriticalTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true -XX:+UseWispMonitor SelectorInitCriticalTest
  */
 
 

--- a/test/com/alibaba/wisp/bug/TestThreadStackTrace.sh
+++ b/test/com/alibaba/wisp/bug/TestThreadStackTrace.sh
@@ -131,7 +131,7 @@ then
 fi
 
 #run
-${JAVA} -XX:+PrintSafepointStatistics  -XX:PrintSafepointStatisticsCount=1 -XX:+UseWisp2 -Dcom.alibaba.wisp.carrierEngines=1 -cp ${TESTCLASSES} ${TEST_CLASS} > output.txt  2>&1
+${JAVA} -XX:+PrintSafepointStatistics  -XX:PrintSafepointStatisticsCount=1 -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.carrierEngines=1 -cp ${TESTCLASSES} ${TEST_CLASS} > output.txt  2>&1
 cat output.txt
 
 function assert()

--- a/test/com/alibaba/wisp/bug/ThreadLockTest.java
+++ b/test/com/alibaba/wisp/bug/ThreadLockTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Test fix of WispCarrier block on Thread.class lock
  * @requires os.family == "linux"
- * @run main/othervm -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -XX:SyncKnobs="ReportSettings=1:QMode=1"  -Dcom.alibaba.wisp.transparentWispSwitch=true ThreadLockTest
+ * @run main/othervm -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -XX:SyncKnobs="ReportSettings=1:QMode=1"  -Dcom.alibaba.wisp.transparentWispSwitch=true ThreadLockTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/bug/ThreadPoolFastShutdownBugTest.java
+++ b/test/com/alibaba/wisp/bug/ThreadPoolFastShutdownBugTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary test shutdown a thread pool which contains non-fully-started thread
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ThreadPoolFastShutdownBugTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ThreadPoolFastShutdownBugTest
  */
 
 import java.util.concurrent.ExecutorService;

--- a/test/com/alibaba/wisp/bug/WispSelectorReadyOpsTest.java
+++ b/test/com/alibaba/wisp/bug/WispSelectorReadyOpsTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary ensure nio program call SelectionKey.is{}able() and got correct result.
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true WispSelectorReadyOpsTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true WispSelectorReadyOpsTest
  */
 
 import java.net.InetSocketAddress;

--- a/test/com/alibaba/wisp/bug/WispSocketLeakWhenConnectTimeoutTest.java
+++ b/test/com/alibaba/wisp/bug/WispSocketLeakWhenConnectTimeoutTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test the fix to fd leakage when socket connect timeout
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true WispSocketLeakWhenConnectTimeoutTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true WispSocketLeakWhenConnectTimeoutTest
  */
 
 import java.io.IOException;

--- a/test/com/alibaba/wisp/close/WispDestroyTest.java
+++ b/test/com/alibaba/wisp/close/WispDestroyTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Test WispCarrier's destroy
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true WispDestroyTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true WispDestroyTest
  */
 
 import com.alibaba.wisp.engine.WispTask;

--- a/test/com/alibaba/wisp/env/CtxClassLoaderIsolateTest.java
+++ b/test/com/alibaba/wisp/env/CtxClassLoaderIsolateTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Verify the context class loader isolation per co-routine
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true CtxClassLoaderIsolateTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true CtxClassLoaderIsolateTest
  */
 
 

--- a/test/com/alibaba/wisp/io/BlockingAccept2Test.java
+++ b/test/com/alibaba/wisp/io/BlockingAccept2Test.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test blocking accept
  * @requires os.family == "linux"
- * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:+UseWisp2 BlockingAccept2Test
+ * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 BlockingAccept2Test
  */
 
 import java.net.InetSocketAddress;

--- a/test/com/alibaba/wisp/io/BlockingAcceptTest.java
+++ b/test/com/alibaba/wisp/io/BlockingAcceptTest.java
@@ -24,8 +24,8 @@
  * @library /lib/testlibrary
  * @summary test blocking accept
  * @requires os.family == "linux"
- * @run main/othervm -XX:ActiveProcessorCount=4 -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true -XX:+UseWispMonitor  BlockingAcceptTest
- * @run main/othervm -XX:ActiveProcessorCount=4 -XX:+UseWisp2 BlockingAcceptTest
+ * @run main/othervm -XX:ActiveProcessorCount=4 -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true -XX:+UseWispMonitor  BlockingAcceptTest
+ * @run main/othervm -XX:ActiveProcessorCount=4 -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 BlockingAcceptTest
  */
 
 import java.net.InetSocketAddress;

--- a/test/com/alibaba/wisp/io/CreateFdOnDemandTest.java
+++ b/test/com/alibaba/wisp/io/CreateFdOnDemandTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Test fix of unconnected Socket fd leak.
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true CreateFdOnDemandTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true CreateFdOnDemandTest
  */
 
 import java.io.File;

--- a/test/com/alibaba/wisp/io/DatagramSocketTest.java
+++ b/test/com/alibaba/wisp/io/DatagramSocketTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Test WispCarrier's DatagramSocket, InitialDirContext use dup socket to query dns.
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true DatagramSocketTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true DatagramSocketTest
  */
 
 

--- a/test/com/alibaba/wisp/io/GlobalPollerTest.java
+++ b/test/com/alibaba/wisp/io/GlobalPollerTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Test for Global Poller
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.transparentAsync=true GlobalPollerTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.transparentAsync=true GlobalPollerTest
 */
 
 import com.alibaba.wisp.engine.WispTask;

--- a/test/com/alibaba/wisp/io/ReuseUdpSocektBufTest.java
+++ b/test/com/alibaba/wisp/io/ReuseUdpSocektBufTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test reuse WispUdpSocket buffer
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ReuseUdpSocektBufTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ReuseUdpSocektBufTest
  */
 
 import java.net.DatagramPacket;

--- a/test/com/alibaba/wisp/io/ShareFdTest.java
+++ b/test/com/alibaba/wisp/io/ShareFdTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test support fd use acorss coroutines
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ShareFdTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ShareFdTest
  */
 
 import sun.misc.SharedSecrets;

--- a/test/com/alibaba/wisp/io/SocketTest.java
+++ b/test/com/alibaba/wisp/io/SocketTest.java
@@ -24,7 +24,7 @@
  * @summary Test WispEngine's Socket
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true SocketTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true SocketTest
  */
 
 import java.io.IOException;

--- a/test/com/alibaba/wisp/io/WispSocketCloseTest.java
+++ b/test/com/alibaba/wisp/io/WispSocketCloseTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test close will wake up blocking wispTask
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true WispSocketCloseTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true WispSocketCloseTest
  */
 
 import java.io.IOException;

--- a/test/com/alibaba/wisp/lock/AQSTest.java
+++ b/test/com/alibaba/wisp/lock/AQSTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Test AQS: CountDownLatch is implement by AQS
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true AQSTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true AQSTest
  */
 
 

--- a/test/com/alibaba/wisp/lock/ElisionSpinTest.java
+++ b/test/com/alibaba/wisp/lock/ElisionSpinTest.java
@@ -24,7 +24,7 @@
  * @summary Test elision spin
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm  -XX:+UseWisp2 -Dcom.alibaba.wisp.carrierEngines=1 ElisionSpinTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.carrierEngines=1 ElisionSpinTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/lock/LockTest.java
+++ b/test/com/alibaba/wisp/lock/LockTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Test ReentrantLock in coroutine environment
  * @requires os.family == "linux"
- * @run main/othervm  -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true LockTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true LockTest
  */
 
 

--- a/test/com/alibaba/wisp/lock/ParkNanoTest.java
+++ b/test/com/alibaba/wisp/lock/ParkNanoTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Test park nanos
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ParkNanoTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ParkNanoTest
  */
 
 

--- a/test/com/alibaba/wisp/lock/UnsafeParkTest.java
+++ b/test/com/alibaba/wisp/lock/UnsafeParkTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Test to verify we can do proper wisp scheduling while calling on Unsafe.park()
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true UnsafeParkTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true UnsafeParkTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/monitor/C2SyncMethodTest.java
+++ b/test/com/alibaba/wisp/monitor/C2SyncMethodTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary test to run a compiled/synchronized method with wisp enabled.
  * @requires os.family == "linux"
- * @run main/othervm -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true C2SyncMethodTest
+ * @run main/othervm -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true C2SyncMethodTest
  */
 public class C2SyncMethodTest {
     public synchronized static void main(String[] args) {

--- a/test/com/alibaba/wisp/monitor/FinalizerTest.java
+++ b/test/com/alibaba/wisp/monitor/FinalizerTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Test unpark in a finalizer  thread.
  * @requires os.family == "linux"
- * @run main/othervm   -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true FinalizerTest
+ * @run main/othervm   -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true FinalizerTest
  */
 
 public class FinalizerTest {

--- a/test/com/alibaba/wisp/monitor/JNICriticalTest.java
+++ b/test/com/alibaba/wisp/monitor/JNICriticalTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Test unpark in JNI critical case
  * @requires os.family == "linux"
- * @run main/othervm   -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true JNICriticalTest
+ * @run main/othervm   -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true JNICriticalTest
  */
 
 

--- a/test/com/alibaba/wisp/monitor/LazyUnparkBugTest.java
+++ b/test/com/alibaba/wisp/monitor/LazyUnparkBugTest.java
@@ -24,7 +24,7 @@
  * @summary T12212948
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true LazyUnparkBugTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true LazyUnparkBugTest
  */
 
 public class LazyUnparkBugTest {

--- a/test/com/alibaba/wisp/monitor/PassTokenTest.java
+++ b/test/com/alibaba/wisp/monitor/PassTokenTest.java
@@ -24,9 +24,9 @@
  * @library /lib/testlibrary
  * @summary Test object lock with coroutine
  * @requires os.family == "linux"
- * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.schedule.policy=PULL PassTokenTest
- * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.schedule.policy=PUSH PassTokenTest
- * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -DcheckStealEnable=true PassTokenTest
+ * @run main/othervm  -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.schedule.policy=PULL PassTokenTest
+ * @run main/othervm  -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.schedule.policy=PUSH PassTokenTest
+ * @run main/othervm  -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -DcheckStealEnable=true PassTokenTest
  */
 
 

--- a/test/com/alibaba/wisp/monitor/SynchronizedTest.java
+++ b/test/com/alibaba/wisp/monitor/SynchronizedTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Basic test for java primitive lock(synchronized)
  * @requires os.family == "linux"
- * @run main/othervm -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true SynchronizedTest
+ * @run main/othervm -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true SynchronizedTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/monitor/WispExitTest.java
+++ b/test/com/alibaba/wisp/monitor/WispExitTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary Ensure we can exit vm when -XX:+UseWispMonitor
  * @requires os.family == "linux"
- * @run main/othervm -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true WispExitTest
+ * @run main/othervm -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true WispExitTest
  */
 public class WispExitTest {
     public static void main(String[] args) throws Exception {

--- a/test/com/alibaba/wisp/thread/DaemonTest.java
+++ b/test/com/alibaba/wisp/thread/DaemonTest.java
@@ -64,7 +64,7 @@ public class DaemonTest {
 
     private static void driver(boolean daemon) throws Exception {
         // we can not use jdk.testlibrary.ProcessTools here, because we need to analyse stdout of a unfinished process
-        Process process = new ProcessBuilder(System.getProperty("java.home") + "/bin/java",
+        Process process = new ProcessBuilder(System.getProperty("java.home") + "/bin/java", "-XX:+UnlockExperimentalVMOptions",
                 "-XX:+UseWisp2", "-cp", System.getProperty("java.class.path"), DaemonTest.class.getName(), Boolean.toString(daemon)).start();
         Thread.sleep(2000);
         byte[] buffer = new byte[1024];

--- a/test/com/alibaba/wisp/thread/DaemonThreadGroupTest.java
+++ b/test/com/alibaba/wisp/thread/DaemonThreadGroupTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Test Daemon Thread Group implementation
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.useCarrierAsPoller=false DaemonThreadGroupTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.useCarrierAsPoller=false DaemonThreadGroupTest
 */
 
 

--- a/test/com/alibaba/wisp/thread/DisableThreadAsWispAtRuntimeTest.java
+++ b/test/com/alibaba/wisp/thread/DisableThreadAsWispAtRuntimeTest.java
@@ -24,7 +24,7 @@
  * @summary this feature is not supported in wisp2, just check compatibility
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true DisableThreadAsWispAtRuntimeTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true DisableThreadAsWispAtRuntimeTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/thread/EngineExecutorTest.java
+++ b/test/com/alibaba/wisp/thread/EngineExecutorTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test submit task to engine.
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true EngineExecutorTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true EngineExecutorTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/thread/InterruptTest.java
+++ b/test/com/alibaba/wisp/thread/InterruptTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary test thread.interrupt() of wispTask
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true InterruptTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true InterruptTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/thread/InterruptedSleepTest.java
+++ b/test/com/alibaba/wisp/thread/InterruptedSleepTest.java
@@ -24,7 +24,7 @@
  * @summary test InterruptedException was thrown by sleep()
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true InterruptedSleepTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true InterruptedSleepTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/thread/IsAliveTest.java
+++ b/test/com/alibaba/wisp/thread/IsAliveTest.java
@@ -24,7 +24,7 @@
  * @summary test thread.isAlive() of wispTask
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true IsAliveTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true IsAliveTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/thread/PreemptTest.java
+++ b/test/com/alibaba/wisp/thread/PreemptTest.java
@@ -24,7 +24,7 @@
  * @summary test wisp time slice preempt
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.carrierEngines=1 PreemptTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.carrierEngines=1 PreemptTest
 
  */
 

--- a/test/com/alibaba/wisp/thread/ThrowErrorTest.java
+++ b/test/com/alibaba/wisp/thread/ThrowErrorTest.java
@@ -24,7 +24,7 @@
  * @summary test coroutine throw Error
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ThrowErrorTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true ThrowErrorTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/timer/OverflowTest.java
+++ b/test/com/alibaba/wisp/timer/OverflowTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Test timer implementation
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine OverflowTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine OverflowTest
  */
 
 

--- a/test/com/alibaba/wisp/timer/SleepRPCTest.java
+++ b/test/com/alibaba/wisp/timer/SleepRPCTest.java
@@ -24,8 +24,8 @@
  * @summary test use sleep in RPC senorina
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true SleepRPCTest
- * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.highPrecisionTimer=true  SleepRPCTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true SleepRPCTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.highPrecisionTimer=true  SleepRPCTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/timer/SleepTest.java
+++ b/test/com/alibaba/wisp/timer/SleepTest.java
@@ -24,8 +24,8 @@
  * @summary test sleep
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true SleepTest
- * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.highPrecisionTimer=true SleepTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true SleepTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.highPrecisionTimer=true SleepTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp/timer/TimerTest.java
+++ b/test/com/alibaba/wisp/timer/TimerTest.java
@@ -23,8 +23,8 @@
  * @test
  * @summary Test timer implement
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine TimerTest
- * @run main/othervm -XX:+EnableCoroutine -Dcom.alibaba.wisp.highPrecisionTimer=true TimerTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine TimerTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.highPrecisionTimer=true TimerTest
  */
 
 

--- a/test/com/alibaba/wisp2/AdjustCarrierTest.java
+++ b/test/com/alibaba/wisp2/AdjustCarrierTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test for adjusting carrier number at runtime
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.growCarrierTickUs=200000  AdjustCarrierTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.growCarrierTickUs=200000  AdjustCarrierTest
  */
 
 

--- a/test/com/alibaba/wisp2/AllThreadAsWispTest.java
+++ b/test/com/alibaba/wisp2/AllThreadAsWispTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary convert all thread to wisp
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true AllThreadAsWispTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true AllThreadAsWispTest
  */
 
 import sun.misc.SharedSecrets;

--- a/test/com/alibaba/wisp2/CarrierAsPollerTest.java
+++ b/test/com/alibaba/wisp2/CarrierAsPollerTest.java
@@ -24,8 +24,8 @@
  * @library /lib/testlibrary
  * @summary verify carrier is doing epoll instead of poller when useCarrierAsPoller is enabled
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.useCarrierAsPoller=true CarrierAsPollerTest
- * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.useCarrierAsPoller=false CarrierAsPollerTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.useCarrierAsPoller=true CarrierAsPollerTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.useCarrierAsPoller=false CarrierAsPollerTest
  */
 
 

--- a/test/com/alibaba/wisp2/CtxClassLoaderInheritanceTest.java
+++ b/test/com/alibaba/wisp2/CtxClassLoaderInheritanceTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test context ClassLoader inherit.
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true CtxClassLoaderInheritanceTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true CtxClassLoaderInheritanceTest
  */
 
 import java.util.concurrent.CountDownLatch;

--- a/test/com/alibaba/wisp2/DispatchTest.java
+++ b/test/com/alibaba/wisp2/DispatchTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary basic wisp2
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor  DispatchTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor  DispatchTest
  */
 
 

--- a/test/com/alibaba/wisp2/EpollWakeupPerfTest.java
+++ b/test/com/alibaba/wisp2/EpollWakeupPerfTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary test selector.wakeup() performance
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2  EpollWakeupPerfTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2  EpollWakeupPerfTest
  */
 
 import java.nio.channels.Selector;

--- a/test/com/alibaba/wisp2/HandOffTest.java
+++ b/test/com/alibaba/wisp2/HandOffTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test long running or blocking syscall task could be retaken
  * @requires os.family == "linux"
- * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.enableHandOff=true -Dcom.alibaba.wisp.handoffPolicy=ADAPTIVE -Dcom.alibaba.wisp.sysmonTickUs=100000 HandOffTest
+ * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.enableHandOff=true -Dcom.alibaba.wisp.handoffPolicy=ADAPTIVE -Dcom.alibaba.wisp.sysmonTickUs=100000 HandOffTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/HandOffWakeUpTest.java
+++ b/test/com/alibaba/wisp2/HandOffWakeUpTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test long running or blocking syscall task could be retaken
  * @requires os.family == "linux"
- * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.enableHandOff=true -Dcom.alibaba.wisp.sysmonTickUs=100000 HandOffWakeUpTest
+ * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.enableHandOff=true -Dcom.alibaba.wisp.sysmonTickUs=100000 HandOffWakeUpTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/HandOffWithStealTest.java
+++ b/test/com/alibaba/wisp2/HandOffWithStealTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test long running or blocking syscall task could be retaken
  * @requires os.family == "linux"
- * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:+UseWisp2 -Dcom.alibaba.wisp.handoffPolicy=ADAPTIVE HandOffWithStealTest
+ * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.handoffPolicy=ADAPTIVE HandOffWithStealTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/MassiveIOTest.java
+++ b/test/com/alibaba/wisp2/MassiveIOTest.java
@@ -24,9 +24,9 @@
  * @library /lib/testlibrary
  * @summary test massive IO
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2 MassiveIOTest
- * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.pollerShardingSize=0 MassiveIOTest
- * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.pollerShardingSize=1000 MassiveIOTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 MassiveIOTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.pollerShardingSize=0 MassiveIOTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.pollerShardingSize=1000 MassiveIOTest
  */
 import java.io.IOException;
 import java.io.InputStream;

--- a/test/com/alibaba/wisp2/MonolithicPollTest.java
+++ b/test/com/alibaba/wisp2/MonolithicPollTest.java
@@ -24,8 +24,8 @@
  * @library /lib/testlibrary
  * @summary verify epollArray is set for Selector.select()
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.monolithicPoll=true MonolithicPollTest
- * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.monolithicPoll=false MonolithicPollTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.monolithicPoll=true MonolithicPollTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.monolithicPoll=false MonolithicPollTest
  */
 
 import com.alibaba.wisp.engine.WispTask;

--- a/test/com/alibaba/wisp2/NioBlockingAcceptTest.java
+++ b/test/com/alibaba/wisp2/NioBlockingAcceptTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test nio blocking accept
  * @requires os.family == "linux"
- * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:ActiveProcessorCount=1 -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true NioBlockingAcceptTest
+ * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:ActiveProcessorCount=1 -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true NioBlockingAcceptTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/ProfileWithHandOffTest.java
+++ b/test/com/alibaba/wisp2/ProfileWithHandOffTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test after long running or blocking syscall task could be retaken, the new carrier thread can be profiled.
  * @requires os.family == "linux"
- * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.enableHandOff=true -Dcom.alibaba.wisp.handoffPolicy=ADAPTIVE -Dcom.alibaba.wisp.enablePerfLog=true -Dcom.alibaba.wisp.logTimeInternalMillis=1000 ProfileWithHandOffTest
+ * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.enableHandOff=true -Dcom.alibaba.wisp.handoffPolicy=ADAPTIVE -Dcom.alibaba.wisp.enablePerfLog=true -Dcom.alibaba.wisp.logTimeInternalMillis=1000 ProfileWithHandOffTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/ProfileWithHandOffTest2.java
+++ b/test/com/alibaba/wisp2/ProfileWithHandOffTest2.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test after long running or blocking syscall task could be retaken, the new carrier thread can be profiled.
  * @requires os.family == "linux"
- * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.enableHandOff=true -Dcom.alibaba.wisp.handoffPolicy=ADAPTIVE -Dcom.alibaba.wisp.sysmonTickUs=100000 -Dcom.alibaba.wisp.enablePerfLog=true -Dcom.alibaba.wisp.logTimeInternalMillis=1000 ProfileWithHandOffTest2
+ * @run main/othervm -Dcom.alibaba.wisp.carrierEngines=1 -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.enableHandOff=true -Dcom.alibaba.wisp.handoffPolicy=ADAPTIVE -Dcom.alibaba.wisp.sysmonTickUs=100000 -Dcom.alibaba.wisp.enablePerfLog=true -Dcom.alibaba.wisp.logTimeInternalMillis=1000 ProfileWithHandOffTest2
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/RemoveWispParentTest.java
+++ b/test/com/alibaba/wisp2/RemoveWispParentTest.java
@@ -24,7 +24,7 @@
  * @summary Test a WispTask will not block when it created a new one and didn't yield to its parent.
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+UseWisp2  RemoveWispParentTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2  RemoveWispParentTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/ReuseWispTaskAfterThreadJoinTest.java
+++ b/test/com/alibaba/wisp2/ReuseWispTaskAfterThreadJoinTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test wisp task reusing after thread.join()
  * @requires os.family == "linux"
- * @run main/othervm  -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true  ReuseWispTaskAfterThreadJoinTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true  ReuseWispTaskAfterThreadJoinTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/ThreadAsWispBlackListTest.java
+++ b/test/com/alibaba/wisp2/ThreadAsWispBlackListTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test all thread as wisp black list
  * @requires os.family == "linux"
- * @run main/othervm  -XX:+UseWisp2 ThreadAsWispBlackListTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 ThreadAsWispBlackListTest
  */
 
 import sun.misc.SharedSecrets;

--- a/test/com/alibaba/wisp2/ThreadJoinTest.java
+++ b/test/com/alibaba/wisp2/ThreadJoinTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test thread.join()
  * @requires os.family == "linux"
- * @run main/othervm  -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true ThreadJoinTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true ThreadJoinTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/TimedWaitTest.java
+++ b/test/com/alibaba/wisp2/TimedWaitTest.java
@@ -23,7 +23,7 @@
  * @test
  * @summary test timed Jvm park
  * @requires os.family == "linux"
- * @run main/othervm -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 TimedWaitTest
+ * @run main/othervm -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 TimedWaitTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/Wisp2GroupTest.java
+++ b/test/com/alibaba/wisp2/Wisp2GroupTest.java
@@ -24,7 +24,7 @@
  * @summary Test WispCounter removing during the shutdown of Wisp2Group
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableHandOff=false  Wisp2GroupTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableHandOff=false  Wisp2GroupTest
  */
 
 import com.alibaba.management.WispCounterMXBean;

--- a/test/com/alibaba/wisp2/Wisp2ShutdownTest.java
+++ b/test/com/alibaba/wisp2/Wisp2ShutdownTest.java
@@ -24,7 +24,7 @@
  * @summary Wisp2ShutdownTest
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 Wisp2ShutdownTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 Wisp2ShutdownTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/Wisp2TimerRemoveTest.java
+++ b/test/com/alibaba/wisp2/Wisp2TimerRemoveTest.java
@@ -24,8 +24,8 @@
  * @library /lib/testlibrary
  * @summary verify canceled timers are removed ASAP
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2 Wisp2TimerRemoveTest
- * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.highPrecisionTimer=true  Wisp2TimerRemoveTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 Wisp2TimerRemoveTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.highPrecisionTimer=true  Wisp2TimerRemoveTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/Wisp2WaitNotifyTest.java
+++ b/test/com/alibaba/wisp2/Wisp2WaitNotifyTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Test Object.wait/notify with coroutine in wisp2
  * @requires os.family == "linux"
- * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 Wisp2WaitNotifyTest
+ * @run main/othervm  -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 Wisp2WaitNotifyTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/Wisp2WithGlobalCacheTest.java
+++ b/test/com/alibaba/wisp2/Wisp2WithGlobalCacheTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test the task exit flow for ThreadAsWisp task
  * @requires os.family == "linux"
- * @run main/othervm -XX:ActiveProcessorCount=2 -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true -Dcom.alibaba.wisp.engineTaskCache=2 Wisp2WithGlobalCacheTest
+ * @run main/othervm -XX:ActiveProcessorCount=2 -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine  -Dcom.alibaba.wisp.transparentWispSwitch=true  -Dcom.alibaba.wisp.version=2 -XX:+UseWispMonitor -Dcom.alibaba.wisp.enableThreadAsWisp=true -Dcom.alibaba.wisp.allThreadAsWisp=true -Dcom.alibaba.wisp.engineTaskCache=2 Wisp2WithGlobalCacheTest
  */
 
 import sun.misc.SharedSecrets;

--- a/test/com/alibaba/wisp2/Wisp2WorkStealTest.java
+++ b/test/com/alibaba/wisp2/Wisp2WorkStealTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary verification of work stealing really happened
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2 -Dcom.alibaba.wisp.schedule.stealRetry=100 -Dcom.alibaba.wisp.schedule.helpStealRetry=100 Wisp2WorkStealTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.schedule.stealRetry=100 -Dcom.alibaba.wisp.schedule.helpStealRetry=100 Wisp2WorkStealTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/WispEngineCurrentTest.java
+++ b/test/com/alibaba/wisp2/WispEngineCurrentTest.java
@@ -24,7 +24,7 @@
  * @summary Test WispEngine semantic change after refactor
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+UseWisp2  WispEngineCurrentTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2  WispEngineCurrentTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/WispInitShutdownTest.java
+++ b/test/com/alibaba/wisp2/WispInitShutdownTest.java
@@ -24,7 +24,7 @@
  * @summary WispInitShutdownTest
  * @requires os.family == "linux"
  * @library /lib/testlibrary
- * @run main/othervm -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 WispInitShutdownTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 WispInitShutdownTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/bug/ConcurrentThreadJoinTest.java
+++ b/test/com/alibaba/wisp2/bug/ConcurrentThreadJoinTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary ensure thread.isAlive() is false after thread.join()
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2 ConcurrentThreadJoinTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 ConcurrentThreadJoinTest
  */
 
 import static jdk.testlibrary.Asserts.assertFalse;

--- a/test/com/alibaba/wisp2/bug/DisableStealBugTest.java
+++ b/test/com/alibaba/wisp2/bug/DisableStealBugTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test bug of update stealEnable fail
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2 DisableStealBugTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 DisableStealBugTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/bug/EpollWakeupTest.java
+++ b/test/com/alibaba/wisp2/bug/EpollWakeupTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test selector.wakeup() dispatched
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2 -verbose:class  EpollWakeupTest 3000
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -verbose:class  EpollWakeupTest 3000
  */
 
 import java.nio.channels.Selector;

--- a/test/com/alibaba/wisp2/bug/IsInNativeTest.java
+++ b/test/com/alibaba/wisp2/bug/IsInNativeTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test Thread.isInNative() is correct
  * @requires os.family == "linux"
- * @run main/othervm -XX:+EnableCoroutine IsInNativeTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine IsInNativeTest
  */
 
 import sun.misc.SharedSecrets;

--- a/test/com/alibaba/wisp2/bug/PreemptWispInternalBugTest.java
+++ b/test/com/alibaba/wisp2/bug/PreemptWispInternalBugTest.java
@@ -41,6 +41,7 @@ public class PreemptWispInternalBugTest {
         if (args.length == 0) {
             for (int i = 0; i < tasks.length; i++) {
                 ProcessBuilder pb = jdk.testlibrary.ProcessTools.createJavaProcessBuilder(
+                        "-XX:+UnlockExperimentalVMOptions",
                         "-XX:+UseWisp2", "-XX:+UnlockDiagnosticVMOptions", "-XX:+VerboseWisp", "-XX:-Inline",
                         "-Xcomp", "-Dcom.alibaba.wisp.sysmonTickUs=100000",
                         PreemptWispInternalBugTest.class.getName(), tasks[i]);

--- a/test/com/alibaba/wisp2/bug/SchedulerQLBugTest.java
+++ b/test/com/alibaba/wisp2/bug/SchedulerQLBugTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary verify queue length not growth infinity
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2 DisableStealBugTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 DisableStealBugTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/bug/Wisp2ThreadObjLeakInThreadGroupTest.java
+++ b/test/com/alibaba/wisp2/bug/Wisp2ThreadObjLeakInThreadGroupTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary test bug fix of thread object leak in thread group
  * @requires os.family == "linux"
- * @run main/othervm -XX:+UseWisp2 Wisp2ThreadObjLeakInThreadGroupTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 Wisp2ThreadObjLeakInThreadGroupTest
  */
 
 import java.util.concurrent.CountDownLatch;

--- a/test/com/alibaba/wisp2/yield/Wisp2YieldTest.java
+++ b/test/com/alibaba/wisp2/yield/Wisp2YieldTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Test yield in wisp2
  * @requires os.family == "linux"
- * @run main/othervm  -XX:-UseBiasedLocking -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.workerEngines=1 Wisp2YieldTest
+ * @run main/othervm  -XX:-UseBiasedLocking -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -XX:+UseWispMonitor -Dcom.alibaba.wisp.transparentWispSwitch=true -Dcom.alibaba.wisp.version=2 -Dcom.alibaba.wisp.workerEngines=1 Wisp2YieldTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/yield/YieldEmptyQueueTest.java
+++ b/test/com/alibaba/wisp2/yield/YieldEmptyQueueTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Verify yield not really happened when queue is empty
  * @requires os.family == "linux"
- * @run main/othervm  -XX:+UseWisp2 YieldEmptyQueueTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 YieldEmptyQueueTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/yield/YieldFewNanosTest.java
+++ b/test/com/alibaba/wisp2/yield/YieldFewNanosTest.java
@@ -24,7 +24,7 @@
  * @library /lib/testlibrary
  * @summary Verify park not happened for a very small interval
  * @requires os.family == "linux"
- * @run main/othervm  -XX:+UseWisp2 YieldFewNanosTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 YieldFewNanosTest
  */
 
 import com.alibaba.wisp.engine.WispEngine;

--- a/test/com/alibaba/wisp2/yield/YieldTimerTest.java
+++ b/test/com/alibaba/wisp2/yield/YieldTimerTest.java
@@ -24,8 +24,8 @@
  * @library /lib/testlibrary
  * @summary Verify timer could be processed when we're yielding
  * @requires os.family == "linux"
- * @run main/othervm  -XX:+UseWisp2 -Dcom.alibaba.wisp.carrierEngines=1 YieldTimerTest
- * @run main/othervm  -XX:+UseWisp2 -Dcom.alibaba.wisp.carrierEngines=1 -Dcom.alibaba.wisp.highPrecisionTimer=true YieldTimerTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.carrierEngines=1 YieldTimerTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.carrierEngines=1 -Dcom.alibaba.wisp.highPrecisionTimer=true YieldTimerTest
  */
 
 


### PR DESCRIPTION
Summary: Add -XX:+UnlockExperimentalVMOptions to all wisp tests

Test Plan: all Wisp tests

Reviewed-by: yuleil, shiyuexw, sanhong

Issue: https://github.com/alibaba/dragonwell8/issues/113