### PR TITLE
[Wisp] Fix Windows compatibility issue by adding dummy getX methods

### DIFF
--- a/src/macosx/classes/com/alibaba/wisp/engine/WispCounter.java
+++ b/src/macosx/classes/com/alibaba/wisp/engine/WispCounter.java
@@ -23,4 +23,63 @@ package com.alibaba.wisp.engine;
 
 final public class WispCounter {
 
+    public long getCompletedTaskCount() {
+        return 0;
+    }
+
+    public long getTotalEnqueueTime() {
+        return 0;
+    }
+
+    public long getEnqueueCount() {
+        return 0;
+    }
+
+    public long getTotalExecutionTime() {
+        return 0;
+    }
+
+    public long getExecutionCount() {
+        return 0;
+    }
+
+    public long getTotalWaitSocketIOTime() {
+        return 0;
+    }
+
+    public long getWaitSocketIOCount() {
+        return 0;
+    }
+
+    public long getTotalBlockingTime() {
+        return 0;
+    }
+
+    public long getUnparkCount() {
+        return 0;
+    }
+
+    public long getMaxEnqueueTime() {
+        return 0;
+    }
+
+    public long getMaxExecutionTime() {
+        return 0;
+    }
+
+    public long getMaxWaitSocketIOTime() {
+        return 0;
+    }
+
+    public long getMaxBlockingTime() {
+        return 0;
+    }
+
+    public long getTaskQueueLength() {
+        return 0;
+    }
+
+    public long getRunningTaskCount() {
+        return 0;
+    }
 }

--- a/src/macosx/classes/com/alibaba/wisp/engine/WispCounterMXBeanImpl.java
+++ b/src/macosx/classes/com/alibaba/wisp/engine/WispCounterMXBeanImpl.java
@@ -22,11 +22,14 @@
 package com.alibaba.wisp.engine;
 
 import com.alibaba.management.WispCounterMXBean;
+import sun.management.Util;
 
 import javax.management.ObjectName;
 import java.util.List;
 
 public class WispCounterMXBeanImpl implements WispCounterMXBean {
+
+    private final static String WISP_COUNTER_MXBEAN_NAME = "com.alibaba.management:type=WispCounter";
 
     @Override
     public List<Boolean> getRunningStates() {
@@ -145,6 +148,6 @@ public class WispCounterMXBeanImpl implements WispCounterMXBean {
 
     @Override
     public ObjectName getObjectName() {
-        throw new UnsupportedOperationException();
+        return Util.newObjectName(WISP_COUNTER_MXBEAN_NAME);
     }
 }

--- a/src/windows/classes/com/alibaba/wisp/engine/WispCounter.java
+++ b/src/windows/classes/com/alibaba/wisp/engine/WispCounter.java
@@ -23,4 +23,63 @@ package com.alibaba.wisp.engine;
 
 final public class WispCounter {
 
+    public long getCompletedTaskCount() {
+        return 0;
+    }
+
+    public long getTotalEnqueueTime() {
+        return 0;
+    }
+
+    public long getEnqueueCount() {
+        return 0;
+    }
+
+    public long getTotalExecutionTime() {
+        return 0;
+    }
+
+    public long getExecutionCount() {
+        return 0;
+    }
+
+    public long getTotalWaitSocketIOTime() {
+        return 0;
+    }
+
+    public long getWaitSocketIOCount() {
+        return 0;
+    }
+
+    public long getTotalBlockingTime() {
+        return 0;
+    }
+
+    public long getUnparkCount() {
+        return 0;
+    }
+
+    public long getMaxEnqueueTime() {
+        return 0;
+    }
+
+    public long getMaxExecutionTime() {
+        return 0;
+    }
+
+    public long getMaxWaitSocketIOTime() {
+        return 0;
+    }
+
+    public long getMaxBlockingTime() {
+        return 0;
+    }
+
+    public long getTaskQueueLength() {
+        return 0;
+    }
+
+    public long getRunningTaskCount() {
+        return 0;
+    }
 }

--- a/src/windows/classes/com/alibaba/wisp/engine/WispCounterMXBeanImpl.java
+++ b/src/windows/classes/com/alibaba/wisp/engine/WispCounterMXBeanImpl.java
@@ -22,11 +22,14 @@
 package com.alibaba.wisp.engine;
 
 import com.alibaba.management.WispCounterMXBean;
+import sun.management.Util;
 
 import javax.management.ObjectName;
 import java.util.List;
 
 public class WispCounterMXBeanImpl implements WispCounterMXBean {
+
+    private final static String WISP_COUNTER_MXBEAN_NAME = "com.alibaba.management:type=WispCounter";
 
     @Override
     public List<Boolean> getRunningStates() {
@@ -145,6 +148,6 @@ public class WispCounterMXBeanImpl implements WispCounterMXBean {
 
     @Override
     public ObjectName getObjectName() {
-        throw new UnsupportedOperationException();
+        return Util.newObjectName(WISP_COUNTER_MXBEAN_NAME);
     }
 }


### PR DESCRIPTION
Summary: as the title

Test Plan: On Windows platform: TestAggressiveHeap.java, TestExcessGCLockerCollections.java and ThreadCpuTimesDeadlock.java

Reviewed-by: yuleil, shiyuexw

Issue: https://github.com/alibaba/dragonwell8/issues/113