### PR TITLE
[Misc] fix failed test com/sun/jdi/StepTest.java

### DIFF
--- a/test/com/sun/jdi/TestScaffold.java
+++ b/test/com/sun/jdi/TestScaffold.java
@@ -752,6 +752,7 @@ abstract public class TestScaffold extends TargetAdapter {
         sr.addClassExclusionFilter("com.oracle.*");
         sr.addClassExclusionFilter("oracle.*");
         sr.addClassExclusionFilter("jdk.internal.*");
+        sr.addClassExclusionFilter("com.alibaba.*");
         sr.addCountFilter(1);
         sr.enable();
         StepEvent retEvent = (StepEvent)waitForRequestedEvent(sr);


### PR DESCRIPTION
Summary: Alibaba's breakpoint needs to be skipped for StepTest.java, otherwise we may enter an unexpected break position.

Reviewed-by: DDH, yuleil

Issue: https://github.com/alibaba/dragonwell8/issues/111