### PR TITLE
[Backport] 8237499: JFR: Include stack trace in the ThreadStart event

### DIFF
--- a/src/share/classes/jdk/jfr/conf/default.jfc
+++ b/src/share/classes/jdk/jfr/conf/default.jfc
@@ -29,6 +29,7 @@
 
     <event name="jdk.ThreadStart">
       <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.ThreadEnd">

--- a/src/share/classes/jdk/jfr/conf/profile.jfc
+++ b/src/share/classes/jdk/jfr/conf/profile.jfc
@@ -29,6 +29,7 @@
 
     <event name="jdk.ThreadStart">
       <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.ThreadEnd">

--- a/test/jdk/jfr/event/runtime/TestThreadStartEndEvents.java
+++ b/test/jdk/jfr/event/runtime/TestThreadStartEndEvents.java
@@ -25,12 +25,17 @@
 
 package jdk.jfr.event.runtime;
 
+import static jdk.test.lib.Asserts.assertEquals;
+import static jdk.test.lib.Asserts.assertNotNull;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedMethod;
+import jdk.jfr.consumer.RecordedStackTrace;
 import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
@@ -62,19 +67,27 @@ public class TestThreadStartEndEvents {
         recording.stop();
 
         int currThreadIndex = 0;
-        long currentThreadId = Thread.currentThread().getId();
         List<RecordedEvent> events = Events.fromRecording(recording);
+        events.sort((e1, e2) -> e1.getStartTime().compareTo(e2.getStartTime()));
         Events.hasEvents(events);
         for (RecordedEvent event : events) {
-            System.out.println("Event:" + event);
-            if (event.getThread().getJavaThreadId() != currentThreadId) {
+            if (!event.getThread().getJavaName().startsWith(THREAD_NAME_PREFIX)) {
                 continue;
             }
+            System.out.println("Event:" + event);
             // Threads should be started and stopped in the correct order.
             Events.assertEventThread(event, threads[currThreadIndex % threads.length]);
             String eventName = currThreadIndex < threads.length ? EVENT_NAME_THREAD_START : EVENT_NAME_THREAD_END;
             if (!eventName.equals(event.getEventType().getName())) {
-                throw new Exception("Expected event of tyoe " + eventName + " but got " + event.getEventType().getName());
+                throw new Exception("Expected event of type " + eventName + " but got " + event.getEventType().getName());
+            }
+
+            if (eventName == EVENT_NAME_THREAD_START) {
+                Events.assertEventThread(event, "parentThread", Thread.currentThread());
+                RecordedStackTrace stackTrace = event.getValue("stackTrace");
+                assertNotNull(stackTrace);
+                RecordedMethod topMethod = stackTrace.getFrames().get(0).getMethod();
+                assertEquals(topMethod.getName(), "startThread");
             }
             currThreadIndex++;
         }


### PR DESCRIPTION
Summary:

Test Plan: test/jdk/jfr/event/runtime/TestThreadStartEndEvents.java

Reviewed-by: zhengxiaolinX, yuleil

Issue: https://github.com/alibaba/dragonwell8/issues/127