### PR TITLE
[Wisp] Fix unexpected socket closed exception

### DIFF
--- a/src/linux/classes/sun/nio/ch/WispSocketImpl.java
+++ b/src/linux/classes/sun/nio/ch/WispSocketImpl.java
@@ -177,6 +177,7 @@ public class WispSocketImpl
         }
 
         protected final SocketChannel ch;
+        private boolean eof = false;
         private ByteBuffer bb = null;
         // Invoker's previous array
         private byte[] bs = null;
@@ -226,6 +227,9 @@ public class WispSocketImpl
 
         private int read0(ByteBuffer bb)
                 throws IOException {
+            if (eof) {
+                return -1;
+            }
             int n;
             try {
                 if (readAhead != null && readAhead.hasRemaining()) {
@@ -242,6 +246,9 @@ public class WispSocketImpl
                 }
 
                 if ((n = ch.read(bb)) != 0) {
+                    if (n == -1) {
+                        eof = true;
+                    }
                     return n;
                 }
 
@@ -265,6 +272,9 @@ public class WispSocketImpl
                 WEA.unregisterEvent();
             }
 
+            if (n == -1) {
+                eof = true;
+            }
             return n;
         }
 

--- a/test/com/alibaba/wisp2/Wisp2SocketCloseExceptionTest.java
+++ b/test/com/alibaba/wisp2/Wisp2SocketCloseExceptionTest.java
@@ -1,0 +1,24 @@
+/*
+ * @test
+ * @summary Verify that the behavior of read a closed socket is consistent
+ * @requires os.family == "linux"
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 Wisp2SocketCloseExceptionTest
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+public class Wisp2SocketCloseExceptionTest {
+    public static void main(String[] args) throws IOException {
+        ServerSocket serverSocket = new ServerSocket(0);
+        Socket fd = new Socket("localhost", serverSocket.getLocalPort());
+        serverSocket.accept().close();
+        InputStream is = fd.getInputStream();
+        is.read();
+        fd.close();
+        is.read();
+    }
+}
+


### PR DESCRIPTION
Summary:
Make the behavior of reading a closed socket to be consistent
after switching wisp.

Test Plan: Wisp2SocketCloseExceptionTest

Reviewed-by: joeyleeeeeee97 shiyuexw

Issue: alibaba/dragonwell8#124