### PR TITLE
[Wisp] Get CPU time in threadMxbean

### DIFF
--- a/src/linux/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/linux/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -326,6 +326,24 @@ public class WispEngine extends AbstractExecutorService {
             public StackTraceElement[] getStackTrace(WispTask task) {
                 return task.getStackTrace();
             }
+
+            @Override
+            public void getCpuTime(long[] ids, long[] times) {
+                WispTask currentTask = WispCarrier.current().getCurrentTask();
+                assert currentTask.getThreadWrapper() != null;
+                for (int i = 0; i < ids.length; i++) {
+                    if (ids[i] == currentTask.getThreadWrapper().getId()) {
+                        times[i] = currentTask.getCpuTime();
+                        continue;
+                    }
+                    for (WispTask wispTask : WispTask.id2Task.values()) {
+                        Thread wispThreadWrapper = wispTask.getThreadWrapper();
+                        if (wispThreadWrapper != null && wispThreadWrapper.getId() == ids[i]) {
+                            times[i] = wispTask.getCpuTime();
+                        }
+                    }
+                }
+            }
         });
     }
 

--- a/src/linux/classes/com/alibaba/wisp/engine/WispTask.java
+++ b/src/linux/classes/com/alibaba/wisp/engine/WispTask.java
@@ -151,6 +151,8 @@ public class WispTask implements Comparable<WispTask> {
     private long parkTime;
     private long blockingTime;
     private long registerEventTime;
+    long enterTs;
+    long totalTs;
 
     // monolithic epoll support
     private volatile long epollArray;
@@ -187,6 +189,8 @@ public class WispTask implements Comparable<WispTask> {
         stealCount        = 0;
         stealFailureCount = 0;
         preemptCount      = 0;
+        totalTs           = 0;
+        enterTs           = 0;
 
         // thread status
         if (thread != null) { // calling from Thread.start()
@@ -604,6 +608,12 @@ public class WispTask implements Comparable<WispTask> {
 
     StackTraceElement[] getStackTrace() {
         return this.threadWrapper.getStackTrace();
+    }
+
+    long getCpuTime() {
+        // concurrent inaccurate is acceptable
+        long currentEnterTs = enterTs;
+        return totalTs + (currentEnterTs == 0 ? 0 : System.nanoTime() - currentEnterTs);
     }
 
     private static final AtomicReferenceFieldUpdater<WispTask, WispCarrier> CARRIER_UPDATER;

--- a/src/share/classes/sun/misc/WispEngineAccess.java
+++ b/src/share/classes/sun/misc/WispEngineAccess.java
@@ -80,4 +80,6 @@ public interface WispEngineAccess {
     boolean enableSocketLock();
 
     StackTraceElement[] getStackTrace(WispTask task);
+
+    void getCpuTime(long[] ids, long[] times);
 }


### PR DESCRIPTION
Summary: Add profile info for all thread converted coroutines,
supporting ThreadMXBean interfaces such as getCpuTime.

Test Plan: com/alibaba/wisp2/WispThreadMXBeanTest.java

Reviewed-by: zhengxiaolinX, yuleil, sanhongli

Issue: https://github.com/alibaba/dragonwell8/issues/136