### PR TITLE
[Wisp] Revert "Fix NIO deadlock"

### DIFF
--- a/src/share/classes/sun/nio/ch/SelectorImpl.java
+++ b/src/share/classes/sun/nio/ch/SelectorImpl.java
@@ -141,28 +141,17 @@ public abstract class SelectorImpl
         // Precondition: Synchronized on this, keys, and selectedKeys
         Set<SelectionKey> cks = cancelledKeys();
         synchronized (cks) {
-            if (cks.isEmpty()) {
-                return;
-            }
-            cks = new HashSet<>(cks);
-            cancelledKeys().clear();
-        }
-        try { // now cks is a thread local copy
-            Iterator<SelectionKey> i = cks.iterator();
-            while (i.hasNext()) {
-                SelectionKeyImpl ski = (SelectionKeyImpl)i.next();
-                try {
-                    implDereg(ski);
-                } catch (SocketException se) {
-                    throw new IOException("Error deregistering key", se);
-                } finally {
-                    i.remove();
-                }
-            }
-        } finally {
             if (!cks.isEmpty()) {
-                synchronized (cancelledKeys()) {
-                    cancelledKeys().addAll(cks);
+                Iterator<SelectionKey> i = cks.iterator();
+                while (i.hasNext()) {
+                    SelectionKeyImpl ski = (SelectionKeyImpl)i.next();
+                    try {
+                        implDereg(ski);
+                    } catch (SocketException se) {
+                        throw new IOException("Error deregistering key", se);
+                    } finally {
+                        i.remove();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Summary:
Revert changes since we do not use NIO as a part of WispEngine.
This reverts commit c6b1deec0b72f858723e0d328599a138da250c10.

Test Plan: Run all jtreg tests

Reviewed-by: yuleil, zhengxiaolinX

Issue: https://github.com/alibaba/dragonwell8/issues/175