### PR TITLE
[Wisp] handle thread uncaught exception

### DIFF
--- a/src/linux/classes/com/alibaba/wisp/engine/WispTask.java
+++ b/src/linux/classes/com/alibaba/wisp/engine/WispTask.java
@@ -246,6 +246,7 @@ public class WispTask implements Comparable<WispTask> {
                     try {
                         runCommand();
                     } catch (Throwable t) {
+                        dispatchUncaughtException(t);
                         throwable = t;
                     } finally {
                         assert timeOut == null;
@@ -274,6 +275,20 @@ public class WispTask implements Comparable<WispTask> {
             rc.run(wrapRunOutsideWisp(runnable));
         } else {
             runOutsideWisp(runnable);
+        }
+    }
+
+    private void dispatchUncaughtException(Throwable t) {
+        try {
+            threadWrapper.getUncaughtExceptionHandler()
+                    .uncaughtException(threadWrapper, t);
+        } catch (Throwable e) {
+            // the default error log is generated with the format
+            // from hotspot JavaThread::exit
+            String defaultErrorLog = String.format(
+                    "\nException: %s thrown from the UncaughtExceptionHandler in thread \"%s\"",
+                    e.getClass().getName(), threadWrapper.getName());
+            System.err.println(defaultErrorLog);
         }
     }
 

--- a/test/com/alibaba/wisp2/WispUncaughtExceptionTest.java
+++ b/test/com/alibaba/wisp2/WispUncaughtExceptionTest.java
@@ -1,0 +1,35 @@
+/*
+ * @test
+ * @summary Test uncaught exception can be handled by thread's UncaughtExceptionHandler
+ * @library /lib/testlibrary
+ * @run main/othervm -XX:+UseWisp2  WispUncaughtExceptionTest
+ */
+
+import static jdk.testlibrary.Asserts.assertTrue;
+
+public class WispUncaughtExceptionTest {
+
+    public static void main(String[] args) throws Exception {
+        runCase(false);
+        // verify that event if the code throws exception in handler,
+        // Wisp still works.
+        runCase(true);
+    }
+
+    private static void runCase(boolean throwInHandler) throws Exception {
+        boolean[] hasBennDispatch = new boolean[1];
+        Thread thread = new Thread(() -> {
+            Thread.currentThread().setUncaughtExceptionHandler((t, ex) -> {
+                hasBennDispatch[0] = true;
+                if (throwInHandler) {
+                    throw new RuntimeException();
+                }
+            });
+            throw new Error();
+        });
+        thread.start();
+        thread.join();
+
+        assertTrue(hasBennDispatch[0]);
+    }
+}


### PR DESCRIPTION
Summary:
Dispatch thread uncaught exception to the UncaughtExceptionHandler.

Test Plan: WispUncaughtTest

Reviewed-by: zhengxiaolinX, sanhong.lsh

Issue: https://github.com/alibaba/dragonwell8/issues/174