### PR TITLE
[Wisp] Fix windows build failure

### DIFF
--- a/src/windows/classes/com/alibaba/wisp/engine/WispThreadWrapper.java
+++ b/src/windows/classes/com/alibaba/wisp/engine/WispThreadWrapper.java
@@ -29,15 +29,9 @@ import java.dyn.CoroutineSupport;
 class WispThreadWrapper extends Thread {
 
     @Override
-    public CoroutineSupport getCoroutineSupport() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void start() {
         throw new UnsupportedOperationException();
     }
-
 
     @Override
     @Deprecated


### PR DESCRIPTION
Summary: Delete the getCoroutineSupport method
from the windows directory.

Test Plan: build

Reviewed-by: joeyleeeeeee97, D-D-H

Issue: alibaba/dragonwell8#198