### PR TITLE
[Wisp] release uncached wisp task and coroutine stack resource

### DIFF
--- a/src/linux/classes/com/alibaba/wisp/engine/WispConfiguration.java
+++ b/src/linux/classes/com/alibaba/wisp/engine/WispConfiguration.java
@@ -56,6 +56,7 @@ class WispConfiguration {
 
     static final boolean WISP_HIGH_PRECISION_TIMER;
     static final int WISP_ENGINE_TASK_CACHE_SIZE;
+    static final int WISP_ENGINE_TASK_GLOBAL_CACHE_SIZE;
     static final int WISP_SCHEDULE_STEAL_RETRY;
     static final int WISP_SCHEDULE_PUSH_RETRY;
     static final int WISP_SCHEDULE_HELP_STEAL_RETRY;
@@ -117,6 +118,7 @@ class WispConfiguration {
         MONOLITHIC_POLL = parseBooleanParameter(p, "com.alibaba.wisp.monolithicPoll", true);
         WISP_HIGH_PRECISION_TIMER = parseBooleanParameter(p, "com.alibaba.wisp.highPrecisionTimer", false);
         WISP_ENGINE_TASK_CACHE_SIZE = parsePositiveIntegerParameter(p, "com.alibaba.wisp.engineTaskCache", 20);
+        WISP_ENGINE_TASK_GLOBAL_CACHE_SIZE = parsePositiveIntegerParameter(p, "com.alibaba.wisp.engineTaskGlobalCache", WORKER_COUNT * 10);
         WISP_SCHEDULE_STEAL_RETRY = parsePositiveIntegerParameter(p, "com.alibaba.wisp.schedule.stealRetry", Math.max(1, WORKER_COUNT / 2));
         WISP_SCHEDULE_PUSH_RETRY = parsePositiveIntegerParameter(p, "com.alibaba.wisp.schedule.pushRetry", WORKER_COUNT);
         WISP_SCHEDULE_HELP_STEAL_RETRY = parsePositiveIntegerParameter(p, "com.alibaba.wisp.schedule.helpStealRetry", Math.max(1, WORKER_COUNT / 4));

--- a/src/share/classes/java/dyn/CoroutineBase.java
+++ b/src/share/classes/java/dyn/CoroutineBase.java
@@ -69,7 +69,7 @@ public abstract class CoroutineBase {
             // threadSupport is fixed by steal()
             threadSupport.beforeResume(this);
 
-            threadSupport.terminateCoroutine();
+            threadSupport.terminateCoroutine(null);
         }
         assert threadSupport.getThread() == SharedSecrets.getJavaLangAccess().currentThread0();
     }

--- a/test/com/alibaba/wisp2/NmtTracingWispTaskRecycleTest.java
+++ b/test/com/alibaba/wisp2/NmtTracingWispTaskRecycleTest.java
@@ -1,0 +1,110 @@
+/*
+ * @test
+ * @library /lib/testlibrary
+ * @summary verification of uncached WispTask resource recycled by JVM
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -XX:ActiveProcessorCount=4 -XX:NativeMemoryTracking=summary NmtTracingWispTaskRecycleTest
+ */
+
+import com.alibaba.wisp.engine.WispEngine;
+import com.alibaba.wisp.engine.WispTask;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static jdk.testlibrary.Asserts.assertTrue;
+
+public class NmtTracingWispTaskRecycleTest {
+
+    public static void main(final String[] args) throws Exception {
+
+        int loop = 0;
+        final int count = 300;
+        long initCoroutineStack = 0;
+        long endCoroutineStack = 0;
+
+        jcmd();
+
+        // step one: create enough wisp task to fill carrier local cache and global
+        // cache.
+        // step two: create more 200 wisp task.
+        for (; loop < 2; loop++) {
+            final CountDownLatch latch0 = new CountDownLatch(count);
+            final CountDownLatch latch1 = new CountDownLatch(1);
+            for (int i = 0; i < count; i++) {
+                WispEngine.dispatch(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            latch0.countDown();
+                            latch1.await();
+                        } catch (final Exception e) {
+                            e.printStackTrace();
+                        }
+                    }
+                });
+            }
+            latch0.await();
+            latch1.countDown();
+            // make sure that all 200 wisp task exit.
+            Thread.sleep(1000);
+            // record wisp task stack size at this point.
+            if (loop == 0) {
+                initCoroutineStack = parseResult(jcmd());
+            } else if (loop == 1) {
+                endCoroutineStack = parseResult(jcmd());
+            }
+        }
+
+        System.out.println(initCoroutineStack);
+        System.out.println(endCoroutineStack);
+
+        // step three: compare Coroutine stack size, it should never grow and all be
+        // released by jvm.
+        assertTrue(initCoroutineStack == endCoroutineStack,
+                "uncached wisp task's memory was not released as expected.");
+    }
+
+    private static List<String> jcmd() throws Exception {
+        final List<String> statusLines = Files.readAllLines(Paths.get("/proc/self/status"));
+        final String pidLine = statusLines.stream().filter(l -> l.startsWith("Pid:")).findAny().orElse("1 -1");
+        final int pid = Integer.valueOf(pidLine.split("\\s+")[1]);
+
+        final Process p = Runtime.getRuntime()
+                .exec(System.getProperty("java.home") + "/../bin/jcmd " + pid + " VM.native_memory");
+        final List<String> result = new BufferedReader(new InputStreamReader(p.getInputStream())).lines()
+                .collect(Collectors.toList());
+        return result;
+    }
+
+    private static long parseResult(final List<String> result) {
+        int i = 0;
+        for (; i < result.size(); i++) {
+            if (result.get(i).contains("CoroutineStack")) {
+                return matchCoroutineStack(result.get(i));
+            }
+        }
+        throw new RuntimeException("ShouldNotReachHere");
+    }
+
+    static final Pattern pattern = Pattern.compile(".*CoroutineStack \\(reserved=(\\d+).*");
+    private static long matchCoroutineStack(final String str) {
+        Matcher matcher = pattern.matcher(str);
+        if (matcher.find()) {
+            System.out.println(str);
+            return Long.parseLong(matcher.group(1));
+        }
+        throw new RuntimeException("ShouldNotReachHere");
+    }
+}

--- a/test/com/alibaba/wisp2/ReleaseWispTaskTest.java
+++ b/test/com/alibaba/wisp2/ReleaseWispTaskTest.java
@@ -1,0 +1,44 @@
+/*
+ * @test
+ * @library /lib/testlibrary
+ * @summary verification of uncached WispTask resource recycled by GC
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -XX:ActiveProcessorCount=2 ReleaseWispTaskTest
+ */
+
+import com.alibaba.wisp.engine.WispEngine;
+import com.alibaba.wisp.engine.WispTask;
+
+import java.lang.reflect.Field;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+
+import static jdk.testlibrary.Asserts.assertTrue;
+
+public class ReleaseWispTaskTest {
+    public static void main(String[] args) throws Exception {
+        CountDownLatch latch0 = new CountDownLatch(5000);
+        CountDownLatch latch1 = new CountDownLatch(1);
+
+        for (int i = 0; i < 5000; i++) {
+            WispEngine.dispatch(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        latch0.countDown();
+                        latch1.await();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+        }
+        Field f =  WispEngine.class.getDeclaredField("groupTaskCache");
+        f.setAccessible(true);
+        Queue<WispTask> queue =  (Queue<WispTask>)f.get(WispEngine.current());
+        assertTrue(queue.size() == 0);
+        latch0.await();
+        latch1.countDown();
+        Thread.sleep(1000);
+        assertTrue(queue.size() == 21);
+    }
+}

--- a/test/com/alibaba/wisp2/WispUncaughtExceptionTest.java
+++ b/test/com/alibaba/wisp2/WispUncaughtExceptionTest.java
@@ -2,7 +2,7 @@
  * @test
  * @summary Test uncaught exception can be handled by thread's UncaughtExceptionHandler
  * @library /lib/testlibrary
- * @run main/othervm -XX:+UseWisp2  WispUncaughtExceptionTest
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2  WispUncaughtExceptionTest
  */
 
 import static jdk.testlibrary.Asserts.assertTrue;


### PR DESCRIPTION
Summary:
Setting an upper limit of cache space for exited wisp tasks, and release
uncached wisp tasks' memory resources, especially stack memory resources.

Test Plan:
test/com/alibaba/wisp2/NmtTracingWispTaskRecycleTest.java,
test/com/alibaba/wisp2/ReleaseWispTaskTest.java.

Reviewed-by: lei.yul, sanhong.lsh, joeylee.lz

Issue: https://github.com/alibaba/dragonwell8/issues/170