### PR TITLE
src/solaris/native/sun/management/LinuxOperatingSystem.c

### DIFF
--- a/src/solaris/native/sun/management/LinuxOperatingSystem.c
+++ b/src/solaris/native/sun/management/LinuxOperatingSystem.c
@@ -60,7 +60,10 @@ static struct perfbuf {
 #define DEC_64 "%lld"
 
 static void next_line(FILE *f) {
-    while (fgetc(f) != '\n');
+	int c;
+	do {
+		c = fgetc(f);
+    } while (fgetc(f) != '\n' && c != EOF);
 }
 
 /**


### PR DESCRIPTION
Fix the dead loop
Summary: if the /proc/stat mount point is changed in container evironment, the while loop may leaded to 100% cpu usage.