### PR TITLE
[Wisp] Get active thread ids from root container

### DIFF
--- a/src/share/classes/com/alibaba/rcm/ResourceContainerMXBeanImpl.java
+++ b/src/share/classes/com/alibaba/rcm/ResourceContainerMXBeanImpl.java
@@ -41,6 +41,9 @@ public class ResourceContainerMXBeanImpl implements ResourceContainerMXBean {
 
     @Override
     public List<Long> getActiveContainerThreadIds(long id) {
+        if (id == ResourceContainer.root().getId()) {
+            return ((AbstractResourceContainer) ResourceContainer.root()).getActiveContainerThreadIds();
+        }
         AbstractResourceContainer container = (AbstractResourceContainer) ResourceContainerMonitor.getContainerById(id);
         return container.getActiveContainerThreadIds();
     }

--- a/test/com/alibaba/rcm/RcmMXBeanTest.java
+++ b/test/com/alibaba/rcm/RcmMXBeanTest.java
@@ -56,6 +56,7 @@ public class RcmMXBeanTest {
                 assertGreaterThan(resourceContainerMXBean.getCPUResourceConsumedAmount(id), 0L);
                 assertFalse(resourceContainerMXBean.getActiveContainerThreadIds(id).isEmpty());
             } else {
+                assertFalse(resourceContainerMXBean.getActiveContainerThreadIds(id).isEmpty());
                 assertTrue(resourceContainerMXBean.getConstraintsById(id).isEmpty());
             }
             if (resourceContainerMXBean.getCPUResourceLimitReachedCount(id) != 0)

--- a/test/com/alibaba/rcm/RcmUtils.java
+++ b/test/com/alibaba/rcm/RcmUtils.java
@@ -1,5 +1,3 @@
-package com.alibaba.rcm;
-
 import com.alibaba.rcm.Constraint;
 import com.alibaba.rcm.ResourceContainer;
 import com.alibaba.tenant.TenantConfiguration;


### PR DESCRIPTION
Summary: Get all active threads from root container.

Test Plan: com/alibaba/rcm/

Reviewed-by: leiyu, sanhong.lsh

Issue: https://github.com/alibaba/dragonwell8/issues/237