### PR TITLE
[Wisp] Adapt `Thread.stackSize`

### DIFF
--- a/src/linux/classes/com/alibaba/wisp/engine/TaskDispatcher.java
+++ b/src/linux/classes/com/alibaba/wisp/engine/TaskDispatcher.java
@@ -27,13 +27,15 @@ class TaskDispatcher implements StealAwareRunnable {
     private final Runnable target;
     private final String name;
     private final Thread thread;
+    private final long stackSize;
 
-    TaskDispatcher(ClassLoader ctxClassLoader, Runnable target, String name, Thread thread) {
+    TaskDispatcher(ClassLoader ctxClassLoader, Runnable target, String name, Thread thread, long stackSize) {
         this.ctxClassLoader = ctxClassLoader;
         this.enqueueTime = WispEngine.getNanoTime();
         this.target = target;
         this.name = name;
         this.thread = thread;
+        this.stackSize = stackSize;
     }
 
     @Override
@@ -41,6 +43,7 @@ class TaskDispatcher implements StealAwareRunnable {
         WispCarrier current = WispCarrier.current();
         current.countEnqueueTime(enqueueTime);
         current.runTaskInternal(target, name, thread,
-                ctxClassLoader == null ? current.current.ctxClassLoader : ctxClassLoader);
+                ctxClassLoader == null ? current.current.ctxClassLoader : ctxClassLoader,
+                this.stackSize);
     }
 }

--- a/src/linux/classes/com/alibaba/wisp/engine/ThreadAsWisp.java
+++ b/src/linux/classes/com/alibaba/wisp/engine/ThreadAsWisp.java
@@ -48,7 +48,7 @@ class ThreadAsWisp {
      * @param target thread's target field
      * @return if condition is satisfied and thread is started as wisp
      */
-    static boolean tryStart(Thread thread, Runnable target) {
+    static boolean tryStart(Thread thread, Runnable target, long stackSize) {
         if (!WispConfiguration.ALL_THREAD_AS_WISP
                 || WispEngine.isEngineThread(thread)
                 || matchBlackList(thread, target)) {
@@ -67,7 +67,7 @@ class ThreadAsWisp {
 
         // pthread_create always return before new thread started, so we should not wait here
         WispEngine.JLA.setWispAlive(thread, true); // thread.isAlive() should be true
-        WispEngine.current().startAsThread(thread, thread.getName(), thread);
+        WispEngine.current().startAsThread(thread, thread.getName(), thread, stackSize);
         return true;
     }
 

--- a/src/linux/classes/com/alibaba/wisp/engine/WispTask.java
+++ b/src/linux/classes/com/alibaba/wisp/engine/WispTask.java
@@ -167,12 +167,19 @@ public class WispTask implements Comparable<WispTask> {
 
     WispControlGroup controlGroup;
 
+    final long stackSize;
+
     WispTask(WispCarrier carrier, Coroutine ctx, boolean isRealTask, boolean isThreadTask) {
+        this(carrier, ctx, isRealTask, isThreadTask, WispConfiguration.STACK_SIZE);
+    }
+
+    WispTask(WispCarrier carrier, Coroutine ctx, boolean isRealTask, boolean isThreadTask, long stackSize) {
         this.isThreadTask = isThreadTask;
         this.id = isRealTask ? idGenerator.addAndGet(1) : -1;
+        this.stackSize = stackSize;
         setCarrier(carrier);
         if (isRealTask) {
-            this.ctx = ctx != null ? ctx : new CacheableCoroutine(WispConfiguration.STACK_SIZE);
+            this.ctx = ctx != null ? ctx : new CacheableCoroutine(this.stackSize);
             this.ctx.setWispTask(id, this, carrier);
         } else {
             this.ctx = null;

--- a/src/macosx/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/macosx/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -143,7 +143,7 @@ public class WispEngine {
             }
 
             @Override
-            public boolean tryStartThreadAsWisp(Thread thread, Runnable target) {
+            public boolean tryStartThreadAsWisp(Thread thread, Runnable target, long stackSize) {
                 return false;
             }
 

--- a/src/share/classes/java/lang/Thread.java
+++ b/src/share/classes/java/lang/Thread.java
@@ -817,7 +817,7 @@ class Thread implements Runnable {
         boolean started = false;
         try {
             if (!(WEA != null && WispEngine.enableThreadAsWisp() &&
-                    WEA.tryStartThreadAsWisp(this, target))) {
+                    WEA.tryStartThreadAsWisp(this, target, this.stackSize))) {
                 start0();
             }
             started = true;

--- a/src/share/classes/sun/misc/WispEngineAccess.java
+++ b/src/share/classes/sun/misc/WispEngineAccess.java
@@ -75,7 +75,7 @@ public interface WispEngineAccess {
 
     boolean isAllThreadAsWisp();
 
-    boolean tryStartThreadAsWisp(Thread thread, Runnable target);
+    boolean tryStartThreadAsWisp(Thread thread, Runnable target, long stackSize);
 
     boolean useDirectSelectorWakeup();
 

--- a/src/windows/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/windows/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -142,7 +142,7 @@ public class WispEngine {
             }
 
             @Override
-            public boolean tryStartThreadAsWisp(Thread thread, Runnable target) {
+            public boolean tryStartThreadAsWisp(Thread thread, Runnable target, long stackSize) {
                 return false;
             }
 

--- a/test/com/alibaba/wisp2/Wisp2StackSizeTest.java
+++ b/test/com/alibaba/wisp2/Wisp2StackSizeTest.java
@@ -1,0 +1,62 @@
+/*
+ * @test
+ * @library /lib/testlibrary
+ * @summary test wisp2 stack_size
+ * @requires os.family == "linux"
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 Wisp2StackSizeTest
+ */
+
+
+import static jdk.testlibrary.Asserts.*;
+
+public class Wisp2StackSizeTest {
+    public static void main(String[] args) {
+        int prevDepth = 0, curDepth = 0;
+
+        for (int i = 128; i <= 1024; i *= 2) {
+            for (int j = 0; j < 10; j++) {
+                curDepth = Math.max(curDepth, RecTester.tryRec(i * 1024));
+            }
+
+            if (prevDepth != 0) {
+                // roughly curDepth / prevDepth ~= 2
+                assertTrue(Math.abs(curDepth - 2 * prevDepth) < prevDepth, i + " " + curDepth + " " + prevDepth);
+            }
+
+            prevDepth = curDepth;
+        }
+    }
+}
+
+class RecTester implements Runnable {
+    /**
+     * Run recursion on {@link Thread} with given stackSize.
+     *
+     * @return recursion depth before {@link StackOverflowError}
+     */
+    public static int tryRec(long stackSize) {
+        RecTester r = new RecTester();
+        Thread t = new Thread(null, r, "", stackSize);
+        t.start();
+        try {
+            t.join();
+        } catch (InterruptedException ignored) {
+        }
+        return r.depth;
+    }
+
+    public int depth = 0;
+
+    @Override
+    public void run() {
+        try {
+            inner();
+        } catch (StackOverflowError ignored) {
+        }
+    }
+
+    private void inner() {
+        depth++;
+        inner();
+    }
+}


### PR DESCRIPTION
Summary:
Previously wisp uses 512k as the stack size and ignores `Thread.stackSize`.
This PR will make wisp to use `Thread.stackSize` as its stack size.

Test Plan: com/alibaba/wisp2/

Reviewed-by: joeyleeeeeee97, yuleil

Issue: alibaba/dragonwell8#240