### PR TITLE
[Wisp] Add ability to mark thread to run as Wisp

### DIFF
--- a/src/linux/classes/com/alibaba/wisp/engine/ThreadAsWisp.java
+++ b/src/linux/classes/com/alibaba/wisp/engine/ThreadAsWisp.java
@@ -35,7 +35,8 @@ class ThreadAsWisp {
 
     private static int nonDaemonCount;
     private static Thread preventShutdownThread;
-
+    // for marking thread as wisp.
+    static final WispTask wispTaskAsMark = new WispTask(WispCarrier.current(), null, false, false);
 
     /**
      * Try to "start thread" as wisp if all listed condition is satisfied:
@@ -49,9 +50,10 @@ class ThreadAsWisp {
      * @return if condition is satisfied and thread is started as wisp
      */
     static boolean tryStart(Thread thread, Runnable target, long stackSize) {
-        if (!WispConfiguration.ALL_THREAD_AS_WISP
-                || WispEngine.isEngineThread(thread)
-                || matchBlackList(thread, target)) {
+        if ((WispEngine.JLA.getWispTask(thread) != wispTaskAsMark)
+                && (!WispConfiguration.ALL_THREAD_AS_WISP
+                    || WispEngine.isEngineThread(thread)
+                    || matchBlackList(thread, target))) {
             return false;
         }
 

--- a/src/linux/classes/com/alibaba/wisp/engine/WispConfiguration.java
+++ b/src/linux/classes/com/alibaba/wisp/engine/WispConfiguration.java
@@ -143,10 +143,6 @@ class WispConfiguration {
                 ENABLE_THREAD_AS_WISP, "-Dcom.alibaba.wisp.enableThreadAsWisp=true");
         checkDependency(CARRIER_AS_POLLER, "-Dcom.alibaba.wisp.useCarrierAsPoller=true",
                 ALL_THREAD_AS_WISP, "-Dcom.alibaba.wisp.allThreadAsWisp=true");
-        if (ENABLE_THREAD_AS_WISP && !ALL_THREAD_AS_WISP) {
-            throw new IllegalArgumentException("shift thread model by stack configuration is no longer supported," +
-                    " use -XX:+UseWisp2 instead");
-        }
     }
 
     private static void checkDependency(boolean cond, String condStr, boolean preRequire, String preRequireStr) {

--- a/src/linux/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/linux/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -382,6 +382,11 @@ public class WispEngine extends AbstractExecutorService {
                 }
                 return 0;
             }
+
+            @Override
+            public void markAsWispThread(Thread thread) {
+                ThreadAsWisp.wispTaskAsMark.setThreadWrapper(thread);
+            }
         });
     }
 

--- a/src/share/classes/java/lang/Thread.java
+++ b/src/share/classes/java/lang/Thread.java
@@ -816,8 +816,7 @@ class Thread implements Runnable {
 
         boolean started = false;
         try {
-            if (!(WEA != null && WispEngine.enableThreadAsWisp() &&
-                    WEA.tryStartThreadAsWisp(this, target, this.stackSize))) {
+            if (!(WEA != null && WEA.tryStartThreadAsWisp(this, target, this.stackSize))) {
                 start0();
             }
             started = true;

--- a/src/share/classes/sun/misc/WispEngineAccess.java
+++ b/src/share/classes/sun/misc/WispEngineAccess.java
@@ -93,4 +93,6 @@ public interface WispEngineAccess {
      * @throws IOException
      */
     int poll(SelectableChannel channel, int interestOps, long timeout) throws IOException;
+
+    void markAsWispThread(Thread thread);
 }

--- a/test/com/alibaba/wisp/MarkAsWispThreadTest.java
+++ b/test/com/alibaba/wisp/MarkAsWispThreadTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/*
+ * @test
+ * @library /lib/testlibrary
+ * @summary Test ability to mark thread as wispThread
+ * @requires os.family == "linux"
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions  -XX:+EnableCoroutine -XX:+UseWisp2 -Dcom.alibaba.wisp.allThreadAsWisp=false -XX:ActiveProcessorCount=5 MarkAsWispThreadTest
+ */
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import sun.misc.SharedSecrets;
+import static jdk.testlibrary.Asserts.*;
+
+
+public class MarkAsWispThreadTest{
+    public static void main(String[] args) throws InterruptedException, ExecutionException {
+        ThreadFactory threadFactory = new WispThreadFactory();
+        ExecutorService executors = Executors.newFixedThreadPool(1, threadFactory);
+        executors.submit(new Runnable() {
+            @Override
+            public void run() {
+                assertTrue(SharedSecrets.getWispEngineAccess().runningAsCoroutine(Thread.currentThread()));
+            }
+        }).get();
+
+//         Threads are not coroutine by default
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                assertFalse(SharedSecrets.getWispEngineAccess().runningAsCoroutine(Thread.currentThread()));
+            }
+        });
+        t.start();
+        t.join();
+    }
+}
+
+class WispThreadFactory implements ThreadFactory{
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread t = new Thread(r);
+        SharedSecrets.getWispEngineAccess().markAsWispThread(t);
+        return t;
+    }
+}


### PR DESCRIPTION
Summary: Add ability to mark thread to run as Wisp

Test Plan: jdk/test/com/alibaba/wisp/MarkAsWispThreadTest

Reviewed-by: yulei, joeyleeeeeee97, zhengxiaolinX

Issue: https://github.com/alibaba/dragonwell8/issues/242