### PR TITLE
[Misc] Fix unstable VersionCheck test

### DIFF
--- a/test/tools/launcher/VersionCheck.java
+++ b/test/tools/launcher/VersionCheck.java
@@ -247,6 +247,10 @@ public class VersionCheck extends TestHelper {
             if (isWindows && !name.endsWith(EXE_FILE_EXT)) {
                 return false;
             }
+            // jgroup requires special permission
+            if (pathname.getName().equals("jgroup")) {
+                return false;
+            }
             for (String x : exclude) {
                 if (name.endsWith(x)) {
                     return false;


### PR DESCRIPTION
Summary: Exclude jgroup version output when enumerating bin dir.

Test Plan: CI pipeline

Reviewed-by: zhengxiaolinX, D-D-H

Issue: alibaba/dragonwell8#273