### PR TITLE
[JFR] Deprecate public JFR Streaming API

### DIFF
--- a/src/share/classes/jdk/jfr/consumer/EventStream.java
+++ b/src/share/classes/jdk/jfr/consumer/EventStream.java
@@ -120,6 +120,7 @@ import jdk.jfr.internal.consumer.FileAccess;
  *
  * @since 14
  */
+@Deprecated
 public interface EventStream extends AutoCloseable {
     /**
      * Creates a stream from the repository of the current Java Virtual Machine

--- a/src/share/classes/jdk/jfr/consumer/RecordingStream.java
+++ b/src/share/classes/jdk/jfr/consumer/RecordingStream.java
@@ -66,6 +66,7 @@ import jdk.jfr.internal.consumer.EventDirectoryStream;
  *
  * @since 14
  */
+@Deprecated
 public final class RecordingStream implements AutoCloseable, EventStream {
 
     private final Recording recording;

--- a/src/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
+++ b/src/share/classes/jdk/jfr/internal/consumer/AbstractEventStream.java
@@ -47,6 +47,7 @@ import jdk.jfr.internal.SecuritySupport;
  * Purpose of this class is to simplify the implementation of
  * an event stream.
  */
+@Deprecated
 abstract class AbstractEventStream implements EventStream {
     private final static AtomicLong counter = new AtomicLong(0);
 


### PR DESCRIPTION
Summary: For maintainability and compatibility, deprecate JFR
Streaming public API, and will revert related backports in the next GA.

Test Plan: jfr tests

Reviewed-by: kelthuzadx, zhengxiaolinX, yuleil

Issue: https://github.com/alibaba/dragonwell8/issues/275